### PR TITLE
Normalize episode duration to HH:MM:SS for iTunes RSS spec

### DIFF
--- a/content/post/0/index.md
+++ b/content/post/0/index.md
@@ -9,7 +9,7 @@ episode: 0
 podcast: Pointer0.mp3
 type: episode
 artwork: default.jpg
-duration: 0:25:25
+duration: 00:25:25
 ---
 
 Questa è la primissima puntata del PointerPodcast, per prima cosa ci presentiamo, siamo Alessandro, Eugenio e Luca e oggi vi parliamo di:

--- a/content/post/1/index.md
+++ b/content/post/1/index.md
@@ -9,7 +9,7 @@ episode: 1
 podcast: Pointer1.mp3
 type: episode
 artwork: default.jpg
-duration: 0:35:20
+duration: 00:35:20
 ---
 
 Seconda puntata di PointerPodcast, oggi parliamo di:

--- a/content/post/10/index.md
+++ b/content/post/10/index.md
@@ -9,7 +9,7 @@ episode: 10
 podcast: Pointer10.mp3
 type: episode
 artwork: default.jpg
-duration: 0:41:46
+duration: 00:41:46
 ---
 
 ## Note della puntata

--- a/content/post/100/index.md
+++ b/content/post/100/index.md
@@ -8,7 +8,7 @@ episode: 100
 podcast: pointer100.mp3
 type: episode
 artwork: pp100.jpeg
-duration: 1:11:36
+duration: 01:11:36
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/101/index.md
+++ b/content/post/101/index.md
@@ -8,7 +8,7 @@ episode: 101
 podcast: pointer101.mp3
 type: episode
 artwork: pp101.jpeg
-duration: 0:42:8
+duration: 00:42:08
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/102/index.md
+++ b/content/post/102/index.md
@@ -8,7 +8,7 @@ episode: 102
 podcast: pointer102.mp3
 type: episode
 artwork: pp102.jpeg
-duration: 0:45:3
+duration: 00:45:03
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/103/index.md
+++ b/content/post/103/index.md
@@ -8,7 +8,7 @@ episode: 103
 podcast: pointer103.mp3
 type: episode
 artwork: pp103.jpeg
-duration: 1:8:26
+duration: 01:08:26
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/104/index.md
+++ b/content/post/104/index.md
@@ -8,7 +8,7 @@ episode: 104
 podcast: pointer104.mp3
 type: episode
 artwork: pp104.jpeg
-duration: 0:24:12
+duration: 00:24:12
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/105/index.md
+++ b/content/post/105/index.md
@@ -8,7 +8,7 @@ episode: 105
 podcast: pointer105.mp3
 type: episode
 artwork: pp105.png
-duration: 0:24:13
+duration: 00:24:13
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/106/index.md
+++ b/content/post/106/index.md
@@ -9,7 +9,7 @@ podcast: pointer106.mp3
 type: episode
 artwork: pp106.jpeg
 tags: ["Quantum Computing"]
-duration: 0:23:13
+duration: 00:23:13
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/107/index.md
+++ b/content/post/107/index.md
@@ -8,7 +8,7 @@ episode: 107
 podcast: pointer107.mp3
 type: episode
 artwork: pp107.jpeg
-duration: 0:38:18
+duration: 00:38:18
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/108/index.md
+++ b/content/post/108/index.md
@@ -8,7 +8,7 @@ episode: 108
 podcast: pointer108.mp3
 type: episode
 artwork: pp108.jpeg
-duration: 0:43:56
+duration: 00:43:56
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/109/index.md
+++ b/content/post/109/index.md
@@ -8,7 +8,7 @@ episode: 109
 podcast: pointer109.mp3
 type: episode
 artwork: pp109.jpeg
-duration: 0:59:38
+duration: 00:59:38
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/11/index.md
+++ b/content/post/11/index.md
@@ -9,7 +9,7 @@ episode: 11
 podcast: Pointer11.mp3
 type: episode
 artwork: default.jpg
-duration: 0:46:4
+duration: 00:46:04
 ---
 
 ## Note della puntata

--- a/content/post/110/index.md
+++ b/content/post/110/index.md
@@ -8,7 +8,7 @@ episode: 110
 podcast: pointer110.mp3
 type: episode
 artwork: pp110.png
-duration: 0:50:58
+duration: 00:50:58
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/111/index.md
+++ b/content/post/111/index.md
@@ -8,7 +8,7 @@ episode: 111
 podcast: pointer111.mp3
 type: episode
 artwork: pp111.jpeg
-duration: 0:43:3
+duration: 00:43:03
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/112/index.md
+++ b/content/post/112/index.md
@@ -8,7 +8,7 @@ episode: 112
 podcast: pointer112.mp3
 type: episode
 artwork: pp112.png
-duration: 0:38:43
+duration: 00:38:43
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/113/index.md
+++ b/content/post/113/index.md
@@ -8,7 +8,7 @@ episode: 113
 podcast: pointer113.mp3
 type: episode
 artwork: pp113.jpeg
-duration: 0:39:23
+duration: 00:39:23
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/114/index.md
+++ b/content/post/114/index.md
@@ -8,7 +8,7 @@ episode: 114
 podcast: pointer114.mp3
 type: episode
 artwork: pp114.png
-duration: 0:41:29
+duration: 00:41:29
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/115/index.md
+++ b/content/post/115/index.md
@@ -9,7 +9,7 @@ podcast: pointer115.mp3
 type: episode
 artwork: pp115.png
 tags: ["Quantum Computing"]
-duration: 0:56:50
+duration: 00:56:50
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/116/index.md
+++ b/content/post/116/index.md
@@ -8,7 +8,7 @@ episode: 116
 podcast: pointer116.mp3
 type: episode
 artwork: pp116.jpeg
-duration: 0:48:11
+duration: 00:48:11
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/117/index.md
+++ b/content/post/117/index.md
@@ -8,7 +8,7 @@ episode: 118
 podcast: pointer117.mp3
 type: episode
 artwork: pp117.png
-duration: 0:57:13
+duration: 00:57:13
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/118/index.md
+++ b/content/post/118/index.md
@@ -8,7 +8,7 @@ episode: 118
 podcast: pointer118.mp3
 type: episode
 artwork: pp118.png
-duration: 0:59:21
+duration: 00:59:21
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/119/index.md
+++ b/content/post/119/index.md
@@ -8,7 +8,7 @@ episode: 119
 podcast: pointer119.mp3
 type: episode
 artwork: pp119.png
-duration: 1:12:41
+duration: 01:12:41
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/12/index.md
+++ b/content/post/12/index.md
@@ -11,7 +11,7 @@ episode: 12
 podcast: Pointer12.mp3
 type: episode
 artwork: default.jpg
-duration: 1:10:58
+duration: 01:10:58
 ---
 
 ## Note della puntata

--- a/content/post/120/index.md
+++ b/content/post/120/index.md
@@ -8,7 +8,7 @@ episode: 120
 podcast: pointer120.mp3
 type: episode
 artwork: pp120.jpeg
-duration: 1:6:23
+duration: 01:06:23
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/121/index.md
+++ b/content/post/121/index.md
@@ -8,7 +8,7 @@ episode: 121
 podcast: pointer121.mp3
 type: episode
 artwork: pp121.jpeg
-duration: 0:38:45
+duration: 00:38:45
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/122/index.md
+++ b/content/post/122/index.md
@@ -8,7 +8,7 @@ episode: 122
 podcast: pointer122.mp3
 type: episode
 artwork: pp122.png
-duration: 0:58:53
+duration: 00:58:53
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/123/index.md
+++ b/content/post/123/index.md
@@ -8,7 +8,7 @@ episode: 123
 podcast: pointer123.mp3
 type: episode
 artwork: pp123.jpeg
-duration: 1:16:57
+duration: 01:16:57
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/124/index.md
+++ b/content/post/124/index.md
@@ -8,7 +8,7 @@ episode: 124
 podcast: pointer124.mp3
 type: episode
 artwork: pp124.jpeg
-duration: 0:55:24
+duration: 00:55:24
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/125/index.md
+++ b/content/post/125/index.md
@@ -8,7 +8,7 @@ episode: 125
 podcast: pointer125.mp3
 type: episode
 artwork: pp125.png
-duration: 0:47:13
+duration: 00:47:13
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/126/index.md
+++ b/content/post/126/index.md
@@ -8,7 +8,7 @@ episode: 126
 podcast: pointer126.mp3
 type: episode
 artwork: pp126.jpeg
-duration: 1:16:11
+duration: 01:16:11
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/127/index.md
+++ b/content/post/127/index.md
@@ -8,7 +8,7 @@ episode: 127
 podcast: pointer127.mp3
 type: episode
 artwork: pp127.jpeg
-duration: 1:33:10
+duration: 01:33:10
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/128/index.md
+++ b/content/post/128/index.md
@@ -8,7 +8,7 @@ episode: 128
 podcast: pointer128.mp3
 type: episode
 artwork: pp128.jpeg
-duration: 0:57:22
+duration: 00:57:22
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/129/index.md
+++ b/content/post/129/index.md
@@ -8,7 +8,7 @@ episode: 129
 podcast: pointer129.mp3
 type: episode
 artwork: pp129.jpeg
-duration: 0:36:3
+duration: 00:36:03
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/13/index.md
+++ b/content/post/13/index.md
@@ -10,7 +10,7 @@ podcast: Pointer13.mp3
 type: episode
 guests: [{"aldodaquino": "aldo_daquino.jpg"}]
 artwork: default.jpg
-duration: 1:13:35
+duration: 01:13:35
 ---
 
 ## Note della puntata

--- a/content/post/130/index.md
+++ b/content/post/130/index.md
@@ -8,7 +8,7 @@ episode: 130
 podcast: pointer130.mp3
 type: episode
 artwork: pp130.jpeg
-duration: 0:59:12
+duration: 00:59:12
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/131/index.md
+++ b/content/post/131/index.md
@@ -8,7 +8,7 @@ episode: 131
 podcast: pointer131.mp3
 type: episode
 artwork: pp131.jpeg
-duration: 0:58:39
+duration: 00:58:39
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/132/index.md
+++ b/content/post/132/index.md
@@ -8,7 +8,7 @@ episode: 132
 podcast: pointer132.mp3
 type: episode
 artwork: pp132.jpeg
-duration: 0:57:6
+duration: 00:57:06
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/133/index.md
+++ b/content/post/133/index.md
@@ -8,7 +8,7 @@ episode: 133
 podcast: pointer133.mp3
 type: episode
 artwork: pp133.png
-duration: 2:9:27
+duration: 02:09:27
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/134/index.md
+++ b/content/post/134/index.md
@@ -8,7 +8,7 @@ episode: 134
 podcast: pointer134.mp3
 type: episode
 artwork: pp134.png
-duration: 1:5:41
+duration: 01:05:41
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/135/index.md
+++ b/content/post/135/index.md
@@ -8,7 +8,7 @@ episode: 135
 podcast: pointer135.mp3
 type: episode
 artwork: pp135.jpeg
-duration: 0:58:15
+duration: 00:58:15
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/136/index.md
+++ b/content/post/136/index.md
@@ -8,7 +8,7 @@ episode: 136
 podcast: pointer136.mp3
 type: episode
 artwork: pp136.jpeg
-duration: 1:16:56
+duration: 01:16:56
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/137/index.md
+++ b/content/post/137/index.md
@@ -8,7 +8,7 @@ episode: 137
 podcast: pointer137.mp3
 type: episode
 artwork: pp137.png
-duration: 1:1:25
+duration: 01:01:25
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/138/index.md
+++ b/content/post/138/index.md
@@ -8,7 +8,7 @@ episode: 138
 podcast: pointer138.mp3
 type: episode
 artwork: pp138.png
-duration: 0:36:54
+duration: 00:36:54
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/139/index.md
+++ b/content/post/139/index.md
@@ -8,7 +8,7 @@ episode: 139
 podcast: pointer139.mp3
 type: episode
 artwork: pp139.png
-duration: 0:59:41
+duration: 00:59:41
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/14/index.md
+++ b/content/post/14/index.md
@@ -9,7 +9,7 @@ episode: 14
 podcast: Pointer14.mp3
 type: episode
 artwork: default.jpg
-duration: 1:10:7
+duration: 01:10:07
 ---
 
 

--- a/content/post/140/index.md
+++ b/content/post/140/index.md
@@ -8,7 +8,7 @@ episode: 140
 podcast: pointer140.mp3
 type: episode
 artwork: pp140.png
-duration: 0:56:12
+duration: 00:56:12
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/141/index.md
+++ b/content/post/141/index.md
@@ -8,7 +8,7 @@ episode: 141
 podcast: pointer141.mp3
 type: episode
 artwork: pp141.png
-duration: 0:48:0
+duration: 00:48:00
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/142/index.md
+++ b/content/post/142/index.md
@@ -8,7 +8,7 @@ episode: 142
 podcast: pointer142.mp3
 type: episode
 artwork: pp142.jpeg
-duration: 1:26:57
+duration: 01:26:57
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/143/index.md
+++ b/content/post/143/index.md
@@ -8,7 +8,7 @@ episode: 143
 podcast: pointer143.mp3
 type: episode
 artwork: pp143.jpeg
-duration: 0:39:16
+duration: 00:39:16
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/144/index.md
+++ b/content/post/144/index.md
@@ -8,7 +8,7 @@ episode: 144
 podcast: pointer144.mp3
 type: episode
 artwork: pp144.jpeg
-duration: 0:47:31
+duration: 00:47:31
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/145/index.md
+++ b/content/post/145/index.md
@@ -8,7 +8,7 @@ episode: 145
 podcast: pointer145.mp3
 type: episode
 artwork: pp145.png
-duration: 1:7:54
+duration: 01:07:54
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/146/index.md
+++ b/content/post/146/index.md
@@ -8,7 +8,7 @@ episode: 146
 podcast: pointer146.mp3
 type: episode
 artwork: pp146.jpeg
-duration: 1:11:58
+duration: 01:11:58
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/147/index.md
+++ b/content/post/147/index.md
@@ -8,7 +8,7 @@ episode: 147
 podcast: pointer147.mp3
 type: episode
 artwork: pp147.jpeg
-duration: 1:3:42
+duration: 01:03:42
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/148/index.md
+++ b/content/post/148/index.md
@@ -8,7 +8,7 @@ episode: 148
 podcast: pointer148.mp3
 type: episode
 artwork: pp148.png
-duration: 0:58:45
+duration: 00:58:45
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/149/index.md
+++ b/content/post/149/index.md
@@ -8,7 +8,7 @@ episode: 149
 podcast: pointer149.mp3
 type: episode
 artwork: pp149.png
-duration: 1:10:53
+duration: 01:10:53
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/15/index.md
+++ b/content/post/15/index.md
@@ -10,7 +10,7 @@ podcast: Pointer15.mp3
 type: episode
 guests: [{"michelesciabarrà": "michele_sciabarra.jpg"}]
 artwork: default.jpg
-duration: 0:39:26
+duration: 00:39:26
 ---
 
 

--- a/content/post/150/index.md
+++ b/content/post/150/index.md
@@ -9,7 +9,7 @@ podcast: pointer150.mp3
 type: episode
 artwork: pp150.png
 tags: ["Quantum Computing"]
-duration: 0:57:48
+duration: 00:57:48
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/151/index.md
+++ b/content/post/151/index.md
@@ -8,7 +8,7 @@ episode: 151
 podcast: pointer151.mp3
 type: episode
 artwork: pp151.jpeg
-duration: 1:4:9
+duration: 01:04:09
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/152/index.md
+++ b/content/post/152/index.md
@@ -8,7 +8,7 @@ episode: 152
 podcast: pointer152.mp3
 type: episode
 artwork: pp152.jpeg
-duration: 0:53:3
+duration: 00:53:03
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/153/index.md
+++ b/content/post/153/index.md
@@ -9,7 +9,7 @@ podcast: pointer153.mp3
 type: episode
 artwork: pp153.png
 tags: ["Quantum Computing"]
-duration: 0:22:0
+duration: 00:22:00
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/154/index.md
+++ b/content/post/154/index.md
@@ -8,7 +8,7 @@ episode: 154
 podcast: pointer154.mp3
 type: episode
 artwork: pp154.png
-duration: 1:10:4
+duration: 01:10:04
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/155/index.md
+++ b/content/post/155/index.md
@@ -8,7 +8,7 @@ episode: 155
 podcast: pointer155.mp3
 type: episode
 artwork: pp155.jpeg
-duration: 1:6:10
+duration: 01:06:10
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/156/index.md
+++ b/content/post/156/index.md
@@ -8,7 +8,7 @@ episode: 156
 podcast: pointer156.mp3
 type: episode
 artwork: pp156.png
-duration: 0:40:35
+duration: 00:40:35
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/157/index.md
+++ b/content/post/157/index.md
@@ -8,7 +8,7 @@ episode: 157
 podcast: pointer157.mp3
 type: episode
 artwork: pp157.jpeg
-duration: 0:36:16
+duration: 00:36:16
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/158/index.md
+++ b/content/post/158/index.md
@@ -8,7 +8,7 @@ episode: 158
 podcast: pointer158.mp3
 type: episode
 artwork: pp158.jpeg
-duration: 1:7:46
+duration: 01:07:46
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/159/index.md
+++ b/content/post/159/index.md
@@ -8,7 +8,7 @@ episode: 159
 podcast: pointer159.mp3
 type: episode
 artwork: pp159.png
-duration: 0:52:49
+duration: 00:52:49
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/16/index.md
+++ b/content/post/16/index.md
@@ -9,7 +9,7 @@ episode: 16
 podcast: Pointer16.mp3
 type: episode
 artwork: default.jpg
-duration: 0:54:5
+duration: 00:54:05
 ---
 
 ## Note della puntata

--- a/content/post/160/index.md
+++ b/content/post/160/index.md
@@ -8,7 +8,7 @@ episode: 160
 podcast: pointer160.mp3
 type: episode
 artwork: pp160.jpeg
-duration: 1:0:54
+duration: 01:00:54
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/161/index.md
+++ b/content/post/161/index.md
@@ -8,7 +8,7 @@ episode: 161
 podcast: pointer161.mp3
 type: episode
 artwork: pp161.png
-duration: 1:32:59
+duration: 01:32:59
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/162/index.md
+++ b/content/post/162/index.md
@@ -8,7 +8,7 @@ episode: 162
 podcast: pointer162.mp3
 type: episode
 artwork: pp162.png
-duration: 1:25:24
+duration: 01:25:24
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/163/index.md
+++ b/content/post/163/index.md
@@ -8,7 +8,7 @@ episode: 163
 podcast: pointer163.mp3
 type: episode
 artwork: pp163.png
-duration: 1:37:4
+duration: 01:37:04
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/164/index.md
+++ b/content/post/164/index.md
@@ -8,7 +8,7 @@ episode: 164
 podcast: pointer164.mp3
 type: episode
 artwork: pp164.png
-duration: 1:24:46
+duration: 01:24:46
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/165/index.md
+++ b/content/post/165/index.md
@@ -8,7 +8,7 @@ episode: 165
 podcast: pointer165.mp3
 type: episode
 artwork: pp165.jpeg
-duration: 1:2:21
+duration: 01:02:21
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/166/index.md
+++ b/content/post/166/index.md
@@ -8,7 +8,7 @@ episode: 166
 podcast: pointer166.mp3
 type: episode
 artwork: pp166.png
-duration: 0:39:53
+duration: 00:39:53
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/167/index.md
+++ b/content/post/167/index.md
@@ -8,7 +8,7 @@ episode: 167
 podcast: pointer167.mp3
 type: episode
 artwork: pp167.jpeg
-duration: 1:22:34
+duration: 01:22:34
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/168/index.md
+++ b/content/post/168/index.md
@@ -8,7 +8,7 @@ episode: 168
 podcast: pointer168.mp3
 type: episode
 artwork: pp168.jpeg
-duration: 0:42:54
+duration: 00:42:54
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/169/index.md
+++ b/content/post/169/index.md
@@ -8,7 +8,7 @@ episode: 169
 podcast: pointer169.mp3
 type: episode
 artwork: pp169.jpeg
-duration: 1:5:21
+duration: 01:05:21
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/17/index.md
+++ b/content/post/17/index.md
@@ -10,7 +10,7 @@ podcast: Pointer17.mp3
 type: episode
 guests: [{"antoniopitasi": "antonio_pitasi.jpg"}]
 artwork: default.jpg
-duration: 1:18:19
+duration: 01:18:19
 ---
 
 

--- a/content/post/170/index.md
+++ b/content/post/170/index.md
@@ -8,7 +8,7 @@ episode: 170
 podcast: pointer170.mp3
 type: episode
 artwork: pp170.jpeg
-duration: 1:5:18
+duration: 01:05:18
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/171/index.md
+++ b/content/post/171/index.md
@@ -8,7 +8,7 @@ episode: 171
 podcast: pointer171.mp3
 type: episode
 artwork: pp171.jpeg
-duration: 0:54:35
+duration: 00:54:35
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/172/index.md
+++ b/content/post/172/index.md
@@ -8,7 +8,7 @@ episode: 172
 podcast: pointer172.mp3
 type: episode
 artwork: pp172.jpeg
-duration: 0:43:51
+duration: 00:43:51
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/173/index.md
+++ b/content/post/173/index.md
@@ -8,7 +8,7 @@ episode: 173
 podcast: pointer173.mp3
 type: episode
 artwork: pp173.jpeg
-duration: 1:15:15
+duration: 01:15:15
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/174/index.md
+++ b/content/post/174/index.md
@@ -9,7 +9,7 @@ episode: 174
 podcast: pointer174.mp3
 type: episode
 artwork: pp174.jpeg
-duration: 0:40:46
+duration: 00:40:46
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/175/index.md
+++ b/content/post/175/index.md
@@ -8,7 +8,7 @@ episode: 175
 podcast: pointer175.mp3
 type: episode
 artwork: pp175.png
-duration: 0:46:58
+duration: 00:46:58
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/176/index.md
+++ b/content/post/176/index.md
@@ -8,7 +8,7 @@ episode: 176
 podcast: pointer176.mp3
 type: episode
 artwork: pp176.jpeg
-duration: 0:48:14
+duration: 00:48:14
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/177/index.md
+++ b/content/post/177/index.md
@@ -8,7 +8,7 @@ episode: 177
 podcast: pointer177.mp3
 type: episode
 artwork: pp177.jpeg
-duration: 0:53:36
+duration: 00:53:36
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/178/index.md
+++ b/content/post/178/index.md
@@ -8,7 +8,7 @@ episode: 178
 podcast: pointer178.mp3
 type: episode
 artwork: pp178.jpeg
-duration: 0:54:2
+duration: 00:54:02
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/179/index.md
+++ b/content/post/179/index.md
@@ -8,7 +8,7 @@ episode: 179
 podcast: pointer179.mp3
 type: episode
 artwork: pp179.png
-duration: 0:53:25
+duration: 00:53:25
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/18/index.md
+++ b/content/post/18/index.md
@@ -9,7 +9,7 @@ episode: 18
 podcast: Pointer18.mp3
 type: episode
 artwork: default.jpg
-duration: 0:52:15
+duration: 00:52:15
 ---
 
 ## Note della puntata

--- a/content/post/180/index.md
+++ b/content/post/180/index.md
@@ -8,7 +8,7 @@ episode: 180
 podcast: pointer180.mp3
 type: episode
 artwork: pp180.png
-duration: 1:4:21
+duration: 01:04:21
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/181/index.md
+++ b/content/post/181/index.md
@@ -8,7 +8,7 @@ episode: 181
 podcast: pointer181.mp3
 type: episode
 artwork: pp181.png
-duration: 0:52:58
+duration: 00:52:58
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/182/index.md
+++ b/content/post/182/index.md
@@ -10,7 +10,7 @@ episode: 182
 podcast: pointer182.mp3
 type: episode
 artwork: pp182.jpeg
-duration: 0:49:30
+duration: 00:49:30
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/183/index.md
+++ b/content/post/183/index.md
@@ -8,7 +8,7 @@ episode: 183
 podcast: pointer183.mp3
 type: episode
 artwork: pp183.png
-duration: 1:13:12
+duration: 01:13:12
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/184/index.md
+++ b/content/post/184/index.md
@@ -8,7 +8,7 @@ episode: 184
 podcast: pointer184.mp3
 type: episode
 artwork: pp184.png
-duration: 0:35:38
+duration: 00:35:38
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/185/index.md
+++ b/content/post/185/index.md
@@ -8,7 +8,7 @@ episode: 185
 podcast: pointer185.mp3
 type: episode
 artwork: pp185.png
-duration: 1:13:46
+duration: 01:13:46
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/186/index.md
+++ b/content/post/186/index.md
@@ -8,7 +8,7 @@ episode: 186
 podcast: pointer186.mp3
 type: episode
 artwork: pp186.png
-duration: 0:47:52
+duration: 00:47:52
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/187/index.md
+++ b/content/post/187/index.md
@@ -8,7 +8,7 @@ episode: 187
 podcast: pointer187.mp3
 type: episode
 artwork: pp187.png
-duration: 0:52:3
+duration: 00:52:03
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/188/index.md
+++ b/content/post/188/index.md
@@ -8,7 +8,7 @@ episode: 188
 podcast: pointer188.mp3
 type: episode
 artwork: pp188.png
-duration: 0:52:17
+duration: 00:52:17
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/189/index.md
+++ b/content/post/189/index.md
@@ -8,7 +8,7 @@ episode: 189
 podcast: pointer189.mp3
 type: episode
 artwork: pp189.png
-duration: 0:41:47
+duration: 00:41:47
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/19/index.md
+++ b/content/post/19/index.md
@@ -9,7 +9,7 @@ episode: 19
 podcast: Pointer19.mp3
 type: episode
 artwork: default.jpg
-duration: 1:2:36
+duration: 01:02:36
 ---
 
 

--- a/content/post/190/index.md
+++ b/content/post/190/index.md
@@ -8,7 +8,7 @@ episode: 190
 podcast: pointer190.mp3
 type: episode
 artwork: pp190.png
-duration: 1:5:19
+duration: 01:05:19
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/191/index.md
+++ b/content/post/191/index.md
@@ -8,7 +8,7 @@ episode: 191
 podcast: pointer191.mp3
 type: episode
 artwork: pp191.png
-duration: 0:55:42
+duration: 00:55:42
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/192/index.md
+++ b/content/post/192/index.md
@@ -8,7 +8,7 @@ episode: 192
 podcast: pointer192.mp3
 type: episode
 artwork: pp192.jpeg
-duration: 0:59:43
+duration: 00:59:43
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/193/index.md
+++ b/content/post/193/index.md
@@ -8,7 +8,7 @@ episode: 193
 podcast: pointer193.mp3
 type: episode
 artwork: pp193.jpeg
-duration: 0:46:40
+duration: 00:46:40
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/194/index.md
+++ b/content/post/194/index.md
@@ -8,7 +8,7 @@ episode: 194
 podcast: pointer194.mp3
 type: episode
 artwork: pp194.jpeg
-duration: 0:53:32
+duration: 00:53:32
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/195/index.md
+++ b/content/post/195/index.md
@@ -8,7 +8,7 @@ episode: 195
 podcast: pointer195.mp3
 type: episode
 artwork: pp195.jpeg
-duration: 0:44:30
+duration: 00:44:30
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/196/index.md
+++ b/content/post/196/index.md
@@ -15,7 +15,7 @@ episode: 196
 podcast: pointer196.mp3
 type: episode
 artwork: pp196.png
-duration: 0:59:20
+duration: 00:59:20
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/197/index.md
+++ b/content/post/197/index.md
@@ -9,7 +9,7 @@ episode: 197
 podcast: pointer197.mp3
 type: episode
 artwork: pp197.jpeg
-duration: 0:57:1
+duration: 00:57:01
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/198/index.md
+++ b/content/post/198/index.md
@@ -8,7 +8,7 @@ episode: 198
 podcast: pointer198.mp3
 type: episode
 artwork: pp198.jpeg
-duration: 1:0:50
+duration: 01:00:50
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/199/index.md
+++ b/content/post/199/index.md
@@ -8,7 +8,7 @@ episode: 199
 podcast: pointer199.mp3
 type: episode
 artwork: pp199.jpeg
-duration: 0:33:3
+duration: 00:33:03
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/2/index.md
+++ b/content/post/2/index.md
@@ -9,7 +9,7 @@ episode: 2
 podcast: Pointer2.mp3
 type: episode
 artwork: default.jpg
-duration: 0:35:35
+duration: 00:35:35
 ---
 
 ## Note della puntata

--- a/content/post/20/index.md
+++ b/content/post/20/index.md
@@ -8,7 +8,7 @@ episode: 20
 podcast: Pointer20.mp3
 type: episode
 artwork: default.jpg
-duration: 0:59:46
+duration: 00:59:46
 ---
 
 

--- a/content/post/200/index.md
+++ b/content/post/200/index.md
@@ -8,7 +8,7 @@ episode: 200
 podcast: pointer200.mp3
 type: episode
 artwork: pp200.png
-duration: 1:5:33
+duration: 01:05:33
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/201/index.md
+++ b/content/post/201/index.md
@@ -8,7 +8,7 @@ episode: 201
 podcast: pointer201.mp3
 type: episode
 artwork: pp201.jpeg
-duration: 0:45:53
+duration: 00:45:53
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/21/index.md
+++ b/content/post/21/index.md
@@ -9,7 +9,7 @@ episode: 21
 podcast: Pointer21.mp3
 type: episode
 artwork: default.jpg
-duration: 0:57:24
+duration: 00:57:24
 ---
 
 ## Note della puntata

--- a/content/post/22/index.md
+++ b/content/post/22/index.md
@@ -9,7 +9,7 @@ episode: 22
 podcast: Pointer22.mp3
 type: episode
 artwork: default.jpg
-duration: 1:13:13
+duration: 01:13:13
 ---
 
 

--- a/content/post/23/index.md
+++ b/content/post/23/index.md
@@ -9,7 +9,7 @@ episode: 23
 podcast: Pointer23.mp3
 type: episode
 artwork: default.jpg
-duration: 1:4:40
+duration: 01:04:40
 ---
 
 ## Note della puntata

--- a/content/post/24/index.md
+++ b/content/post/24/index.md
@@ -9,7 +9,7 @@ episode: 24
 podcast: Pointer24.mp3
 type: episode
 artwork: default.jpg
-duration: 0:54:44
+duration: 00:54:44
 ---
 
 ## Note della puntata

--- a/content/post/25/index.md
+++ b/content/post/25/index.md
@@ -15,7 +15,7 @@ guests:
     ]
 artwork: default.jpg
 tags: ["Quantum Computing"]
-duration: 0:57:28
+duration: 00:57:28
 ---
 
 ## Note della puntata

--- a/content/post/26/index.md
+++ b/content/post/26/index.md
@@ -11,7 +11,7 @@ type: episode
 guests: [{"vincenzodinicola": "vincenzo_dinicola.jpg"}]
 artwork: default.jpg
 
-duration: 0:54:8
+duration: 00:54:08
 ---
 
 ## Note della puntata

--- a/content/post/27/index.md
+++ b/content/post/27/index.md
@@ -10,7 +10,7 @@ podcast: pointer27.mp3
 type: episode
 guests: [{"emanueltesoriello": "emanuel_tesoriello.jpg"}]
 artwork: default.jpg
-duration: 1:14:27
+duration: 01:14:27
 ---
 
 ## Note della puntata

--- a/content/post/28/index.md
+++ b/content/post/28/index.md
@@ -11,7 +11,7 @@ type: episode
 guests: [{"federicopoloni": "federico_poloni.jpg"}]
 artwork: default.jpg
 
-duration: 0:49:3
+duration: 00:49:03
 ---
 
 ## Note della puntata

--- a/content/post/29/index.md
+++ b/content/post/29/index.md
@@ -10,7 +10,7 @@ podcast: Pointer29.mp3
 type: episode
 artwork: default.jpg
 
-duration: 1:5:31
+duration: 01:05:31
 ---
 
 

--- a/content/post/3/index.md
+++ b/content/post/3/index.md
@@ -9,7 +9,7 @@ episode: 3
 podcast: Pointer03.mp3
 type: episode
 artwork: default.jpg
-duration: 0:48:21
+duration: 00:48:21
 ---
 
 I nostri contatti:

--- a/content/post/30/index.md
+++ b/content/post/30/index.md
@@ -9,7 +9,7 @@ episode: 30
 podcast: pointer30.mp3
 type: episode
 artwork: default.jpg
-duration: 1:8:33
+duration: 01:08:33
 ---
 
 ## Note della puntata

--- a/content/post/31/index.md
+++ b/content/post/31/index.md
@@ -11,7 +11,7 @@ type: episode
 guests: [{"mauromurru": "mauro_murru.jpg"}]
 artwork: default.jpg
 
-duration: 1:52:39
+duration: 01:52:39
 ---
 
 ## Note della puntata

--- a/content/post/32/index.md
+++ b/content/post/32/index.md
@@ -10,7 +10,7 @@ podcast: pointer32.mp3
 type: episode
 guests: [{"andreadraghetti": "andrea_draghetti.jpg"}]
 artwork: default.jpg
-duration: 1:21:57
+duration: 01:21:57
 ---
 
 

--- a/content/post/33/index.md
+++ b/content/post/33/index.md
@@ -9,7 +9,7 @@ episode: 33
 podcast: pointer33.mp3
 type: episode
 artwork: default.jpg
-duration: 0:55:12
+duration: 00:55:12
 ---
 
 ## Note della puntata

--- a/content/post/34/index.md
+++ b/content/post/34/index.md
@@ -9,7 +9,7 @@ episode: 34
 podcast: pointer34.mp3
 type: episode
 artwork: pp34.png
-duration: 0:42:35
+duration: 00:42:35
 ---
 
 ## Note della puntata

--- a/content/post/35/index.md
+++ b/content/post/35/index.md
@@ -10,7 +10,7 @@ podcast: pointer35.mp3
 type: episode
 guests: [{"nicolacorti": "nicola_corti.jpg"}]
 artwork: nicolacorti.jpg
-duration: 1:54:4
+duration: 01:54:04
 ---
 
 ## Note della puntata

--- a/content/post/36/index.md
+++ b/content/post/36/index.md
@@ -9,7 +9,7 @@ episode: 36
 podcast: pointer36.mp3
 type: episode
 artwork: pp36.jpg
-duration: 1:1:51
+duration: 01:01:51
 ---
 
 

--- a/content/post/37/index.md
+++ b/content/post/37/index.md
@@ -10,7 +10,7 @@ podcast: pointer37.mp3
 type: episode
 guests: [{"priscillaraucci": "priscilla_raucci.jpg"}]
 artwork: prisci.jpg
-duration: 1:5:17
+duration: 01:05:17
 ---
 ## Note della puntata
 

--- a/content/post/38/index.md
+++ b/content/post/38/index.md
@@ -9,7 +9,7 @@ podcast: pointer38.mp3
 type: episode
 # guests: [{ "maurocoletto": "mauro_coletto.jpg" }]
 artwork: maurocoletto.jpg
-duration: 0:55:28
+duration: 00:55:28
 ---
 
 ## Note della puntata

--- a/content/post/39/index.md
+++ b/content/post/39/index.md
@@ -10,7 +10,7 @@ type: episode
 guests: [{ "simoneseverini": "simone_severini.jpg" }]
 artwork: severini.jpg
 tags: ["Quantum Computing"]
-duration: 0:41:49
+duration: 00:41:49
 ---
 
 ## Note della puntata

--- a/content/post/4/index.md
+++ b/content/post/4/index.md
@@ -11,7 +11,7 @@ podcast: Pointer04.mp3
 type: episode
 guests: [{"carloalessi": "carlo_alessi.jpg"}]
 artwork: default.jpg
-duration: 0:33:39
+duration: 00:33:39
 ---
 ## Note della puntata
 

--- a/content/post/40/index.md
+++ b/content/post/40/index.md
@@ -11,7 +11,7 @@ type: episode
 guests: [{"lucapappalardo": "luca_pappalardo.jpg"}]
 artwork: lucapappalardo.jpg
 
-duration: 0:50:27
+duration: 00:50:27
 ---
 
 ## Note della puntata

--- a/content/post/41/index.md
+++ b/content/post/41/index.md
@@ -10,7 +10,7 @@ podcast: pointer41.mp3
 type: episode
 guests: [{"dianabernabei": "diana_bernabei.jpg"}]
 artwork: dianabernabei.jpg
-duration: 1:3:44
+duration: 01:03:44
 ---
 
 

--- a/content/post/42/index.md
+++ b/content/post/42/index.md
@@ -9,7 +9,7 @@ episode: 42
 podcast: pointer42.mp3
 type: episode
 artwork: pp42.png
-duration: 0:26:14
+duration: 00:26:14
 ---
 
 

--- a/content/post/43/index.md
+++ b/content/post/43/index.md
@@ -11,7 +11,7 @@ type: episode
 guests: [{ "davideventurelli": "davide_venturelli.jpg" }]
 artwork: pp43.png
 tags: ["Quantum Computing"]
-duration: 0:41:52
+duration: 00:41:52
 ---
 
 ## Note della puntata

--- a/content/post/44/index.md
+++ b/content/post/44/index.md
@@ -9,7 +9,7 @@ episode: 44
 podcast: pointer44.mp3
 type: episode
 artwork: pp44.jpg
-duration: 0:32:30
+duration: 00:32:30
 ---
 
 ## Note della puntata

--- a/content/post/45/index.md
+++ b/content/post/45/index.md
@@ -13,7 +13,7 @@ guests: [{"emanueltesoriello": "emanuel_tesoriello.jpg"},
         {"giacomocerquone": "giacomo_cerquone.jpg"},
         {"giorgioboa": "giorgio_boa.jpg"}]
 artwork: italiancoders.jpg
-duration: 0:47:39
+duration: 00:47:39
 ---
 
 ## Note della puntata

--- a/content/post/46/index.md
+++ b/content/post/46/index.md
@@ -10,7 +10,7 @@ podcast: pointer46.mp3
 type: episode
 guests: [{"federicoterzi": "federico_terzi.jpg"}]
 artwork: pp46.jpg
-duration: 0:40:33
+duration: 00:40:33
 ---
 
 ## Note della puntata

--- a/content/post/47/index.md
+++ b/content/post/47/index.md
@@ -9,7 +9,7 @@ episode: 47
 podcast: pointer47.mp3
 type: episode
 artwork: pp47.jpg
-duration: 0:38:21
+duration: 00:38:21
 ---
 
 ## Note della puntata

--- a/content/post/48/index.md
+++ b/content/post/48/index.md
@@ -10,7 +10,7 @@ podcast: pointer48.mp3
 type: episode
 guests: [{"jagasantagostino": "jaga_santagostino.jpg"}]
 artwork: jaga.png
-duration: 0:54:54
+duration: 00:54:54
 ---
 
 ## Note della puntata

--- a/content/post/49/index.md
+++ b/content/post/49/index.md
@@ -10,7 +10,7 @@ podcast: pointer49.mp3
 type: episode
 guests: [{ "antoniogulli": "antonio_gulli.jpg" }]
 artwork: gulli.jpg
-duration: 0:31:37
+duration: 00:31:37
 ---
 
 

--- a/content/post/5/index.md
+++ b/content/post/5/index.md
@@ -9,7 +9,7 @@ episode: 5
 podcast: Pointer05.mp3
 type: episode
 artwork: default.jpg
-duration: 0:47:14
+duration: 00:47:14
 ---
 
 ## Note della puntata

--- a/content/post/50/index.md
+++ b/content/post/50/index.md
@@ -12,7 +12,7 @@ episode: 50
 podcast: pointer50.mp3
 type: episode
 artwork: pp50.jpg
-duration: 0:37:55
+duration: 00:37:55
 ---
 
 

--- a/content/post/51/index.md
+++ b/content/post/51/index.md
@@ -16,7 +16,7 @@ episode: 51
 podcast: pointer51.mp3
 type: episode
 artwork: default.jpg
-duration: 0:46:1
+duration: 00:46:01
 ---
 
 ## Note della puntata

--- a/content/post/52/index.md
+++ b/content/post/52/index.md
@@ -17,7 +17,7 @@ podcast: pointer52.mp3
 type: episode
 guests: [{"diegocolombo": "diego_colombo.jpg"}]
 artwork: pp52.jpg
-duration: 0:48:27
+duration: 00:48:27
 ---
 
 

--- a/content/post/53/index.md
+++ b/content/post/53/index.md
@@ -16,7 +16,7 @@ podcast: pointer53.mp3
 type: episode
 guests: [{"remoandreoli": "remo_andreoli.jpg"}]
 artwork: remo.jpg
-duration: 0:33:26
+duration: 00:33:26
 ---
 
 

--- a/content/post/54/index.md
+++ b/content/post/54/index.md
@@ -15,7 +15,7 @@ episode: 54
 podcast: pointer54.mp3
 type: episode
 artwork: pp54.jpg
-duration: 0:41:51
+duration: 00:41:51
 ---
 
 

--- a/content/post/55/index.md
+++ b/content/post/55/index.md
@@ -14,7 +14,7 @@ episode: 55
 podcast: pointer55.mp3
 type: episode
 artwork: pp55.jpg
-duration: 0:47:30
+duration: 00:47:30
 ---
 
 

--- a/content/post/56/index.md
+++ b/content/post/56/index.md
@@ -18,7 +18,7 @@ podcast: pointer56.mp3
 type: episode
 guests: [{"ceciliapanigutti": "cecilia_panigutti.jpg"}, {"mattiasetzu": "mattia_setzu.jpg"}]
 artwork: pp56.jpg
-duration: 0:58:35
+duration: 00:58:35
 ---
 
 

--- a/content/post/57/index.md
+++ b/content/post/57/index.md
@@ -17,7 +17,7 @@ podcast: pointer57.mp3
 type: episode
 guests: [{"riccardocipolleschi": "riccardo_cipolleschi.jpg"}]
 artwork: pp57.jpg
-duration: 0:39:12
+duration: 00:39:12
 ---
 ## Note della puntata 
 

--- a/content/post/58/index.md
+++ b/content/post/58/index.md
@@ -13,7 +13,7 @@ podcast: pointer58.mp3
 type: episode
 guests: [{"francescoromano": "francesco_romano.jpg"}]
 artwork: pp58.jpg
-duration: 0:33:59
+duration: 00:33:59
 ---
 
 

--- a/content/post/59/index.md
+++ b/content/post/59/index.md
@@ -13,7 +13,7 @@ podcast: pointer59.mp3
 type: episode
 guests: [{"lucarestagno": "luca_restagno.jpg"}]
 artwork: lucarestagno.jpg
-duration: 0:32:54
+duration: 00:32:54
 ---
 
 ## Note della puntata 

--- a/content/post/6/index.md
+++ b/content/post/6/index.md
@@ -9,7 +9,7 @@ episode: 6
 podcast: Pointer06.mp3
 type: episode
 artwork: default.jpg
-duration: 0:46:54
+duration: 00:46:54
 ---
 
 ## Note della puntata

--- a/content/post/60/index.md
+++ b/content/post/60/index.md
@@ -19,7 +19,7 @@ guests: [{"javierignacio": "javier_ignacio.jpg"},
         {"davidmarzi": "david_marzi.jpg"},
         {"giuseppechecchia": "giuseppe_checchia.jpg"}]
 artwork: pp60.jpg
-duration: 1:11:3
+duration: 01:11:03
 ---
 
 

--- a/content/post/61/index.md
+++ b/content/post/61/index.md
@@ -14,7 +14,7 @@ episode: 61
 podcast: pointer61.mp3
 type: episode
 artwork: artwork_pp61.jpg
-duration: 0:56:11
+duration: 00:56:11
 ---
 
 

--- a/content/post/62/index.md
+++ b/content/post/62/index.md
@@ -9,7 +9,7 @@ podcast: pointer62.mp3
 type: episode
 artwork: C38DF23A-203D-4B8F-A283-0263A245D9AE.jpeg
 guests: [{"michmurabito": "mich_murabito.jpeg"}]
-duration: 1:4:20
+duration: 01:04:20
 ---
  
  

--- a/content/post/63/index.md
+++ b/content/post/63/index.md
@@ -8,7 +8,7 @@ episode: 63
 podcast: pointer63.mp3
 type: episode
 artwork: pp63.jpg
-duration: 0:52:16
+duration: 00:52:16
 --- 
 
 

--- a/content/post/64/index.md
+++ b/content/post/64/index.md
@@ -8,7 +8,7 @@ episode: 64
 podcast: pointer64.mp3
 type: episode
 artwork: pp64.png
-duration: 1:16:39
+duration: 01:16:39
 --- 
 
 

--- a/content/post/65/index.md
+++ b/content/post/65/index.md
@@ -8,7 +8,7 @@ episode: 65
 podcast: pointer65.mp3
 type: episode
 artwork: pp65.png
-duration: 1:3:15
+duration: 01:03:15
 --- 
 
 

--- a/content/post/66/index.md
+++ b/content/post/66/index.md
@@ -8,7 +8,7 @@ episode: 66
 podcast: pointer66.mp3
 type: episode
 artwork: pp66.png
-duration: 0:51:1
+duration: 00:51:01
 --- 
 
 

--- a/content/post/67/index.md
+++ b/content/post/67/index.md
@@ -8,7 +8,7 @@ episode: 67
 podcast: pointer67.mp3
 type: episode
 artwork: pp67.jpg
-duration: 0:35:39
+duration: 00:35:39
 --- 
 
 

--- a/content/post/68/index.md
+++ b/content/post/68/index.md
@@ -8,7 +8,7 @@ episode: 68
 podcast: pointer68.mp3
 type: episode
 artwork: pp68.png
-duration: 0:43:45
+duration: 00:43:45
 --- 
 
 

--- a/content/post/69/index.md
+++ b/content/post/69/index.md
@@ -8,7 +8,7 @@ episode: 69
 podcast: pointer69.mp3
 type: episode
 artwork: pp69.png
-duration: 0:51:59
+duration: 00:51:59
 --- 
 
 

--- a/content/post/7/index.md
+++ b/content/post/7/index.md
@@ -9,7 +9,7 @@ episode: 7
 podcast: Pointer07.mp3
 type: episode
 artwork: default.jpg
-duration: 1:18:37
+duration: 01:18:37
 ---
 
 ## Note della puntata

--- a/content/post/70/index.md
+++ b/content/post/70/index.md
@@ -8,7 +8,7 @@ episode: 70
 podcast: pointer70.mp3
 type: episode
 artwork: pp70.png
-duration: 0:26:6
+duration: 00:26:06
 --- 
 
 

--- a/content/post/71/index.md
+++ b/content/post/71/index.md
@@ -8,7 +8,7 @@ episode: 71
 podcast: pointer71.mp3
 type: episode
 artwork: pp71.png
-duration: 0:58:12
+duration: 00:58:12
 --- 
 
 

--- a/content/post/72/index.md
+++ b/content/post/72/index.md
@@ -8,7 +8,7 @@ episode: 72
 podcast: pointer72.mp3
 type: episode
 artwork: pp72.png
-duration: 0:47:44
+duration: 00:47:44
 --- 
 
 

--- a/content/post/73/index.md
+++ b/content/post/73/index.md
@@ -9,7 +9,7 @@ podcast: pointer73.mp3
 type: episode
 artwork: pp73.png
 guests: [{"emanuelebartolesi": "emanuele_bartolesi.jpg"}]
-duration: 1:26:21
+duration: 01:26:21
 --- 
 
 

--- a/content/post/74/index.md
+++ b/content/post/74/index.md
@@ -8,7 +8,7 @@ episode: 74
 podcast: pointer74.mp3
 type: episode
 artwork: pp74.png
-duration: 1:12:52
+duration: 01:12:52
 --- 
 
 

--- a/content/post/75/index.md
+++ b/content/post/75/index.md
@@ -8,7 +8,7 @@ episode: 75
 podcast: pointer75.mp3
 type: episode
 artwork: pp75.png
-duration: 0:51:40
+duration: 00:51:40
 --- 
 
 

--- a/content/post/76/index.md
+++ b/content/post/76/index.md
@@ -8,7 +8,7 @@ episode: 76
 podcast: pointer76.mp3
 type: episode
 artwork: pp76.png
-duration: 0:38:38
+duration: 00:38:38
 --- 
 
 

--- a/content/post/77/index.md
+++ b/content/post/77/index.md
@@ -8,7 +8,7 @@ episode: 77
 podcast: pointer77.mp3
 type: episode
 artwork: pp77.png
-duration: 1:13:36
+duration: 01:13:36
 --- 
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/78/index.md
+++ b/content/post/78/index.md
@@ -8,7 +8,7 @@ episode: 78
 podcast: pointer78.mp3
 type: episode
 artwork: pp78.png
-duration: 0:57:23
+duration: 00:57:23
 --- 
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/79/index.md
+++ b/content/post/79/index.md
@@ -8,7 +8,7 @@ episode: 79
 podcast: pointer79.mp3
 type: episode
 artwork: pp79.png
-duration: 0:57:15
+duration: 00:57:15
 --- 
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/8/index.md
+++ b/content/post/8/index.md
@@ -9,7 +9,7 @@ episode: 8
 podcast: Pointer08.mp3
 type: episode
 artwork: default.jpg
-duration: 1:6:37
+duration: 01:06:37
 ---
 
 ## Note della puntata

--- a/content/post/80/index.md
+++ b/content/post/80/index.md
@@ -8,7 +8,7 @@ episode: 80
 podcast: pointer80.mp3
 type: episode
 artwork: pp80.jpeg
-duration: 1:6:25
+duration: 01:06:25
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/81/index.md
+++ b/content/post/81/index.md
@@ -8,7 +8,7 @@ episode: 81
 podcast: pointer81.mp3
 type: episode
 artwork: pp81.jpeg
-duration: 0:39:7
+duration: 00:39:07
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/82/index.md
+++ b/content/post/82/index.md
@@ -8,7 +8,7 @@ episode: 82
 podcast: pointer82.mp3
 type: episode
 artwork: pp82.png
-duration: 0:49:51
+duration: 00:49:51
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/83/index.md
+++ b/content/post/83/index.md
@@ -8,7 +8,7 @@ episode: 83
 podcast: pointer83.mp3
 type: episode
 artwork: pp83.jpeg
-duration: 0:41:51
+duration: 00:41:51
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/84/index.md
+++ b/content/post/84/index.md
@@ -8,7 +8,7 @@ episode: 84
 podcast: pointer84.mp3
 type: episode
 artwork: pp84.jpeg
-duration: 1:2:2
+duration: 01:02:02
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/85/index.md
+++ b/content/post/85/index.md
@@ -8,7 +8,7 @@ episode: 85
 podcast: pointer85.mp3
 type: episode
 artwork: pp85.jpeg
-duration: 0:53:31
+duration: 00:53:31
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/86/index.md
+++ b/content/post/86/index.md
@@ -8,7 +8,7 @@ episode: 86
 podcast: pointer86.mp3
 type: episode
 artwork: pp86.png
-duration: 0:48:49
+duration: 00:48:49
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/87/index.md
+++ b/content/post/87/index.md
@@ -8,7 +8,7 @@ episode: 87
 podcast: pointer87.mp3
 type: episode
 artwork: pp87.jpeg
-duration: 0:48:32
+duration: 00:48:32
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/88/index.md
+++ b/content/post/88/index.md
@@ -8,7 +8,7 @@ episode: 88
 podcast: pointer88.mp3
 type: episode
 artwork: pp88.jpeg
-duration: 0:52:1
+duration: 00:52:01
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/89/index.md
+++ b/content/post/89/index.md
@@ -8,7 +8,7 @@ episode: 89
 podcast: pointer89.mp3
 type: episode
 artwork: pp89.jpeg
-duration: 1:10:37
+duration: 01:10:37
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/9/index.md
+++ b/content/post/9/index.md
@@ -8,7 +8,7 @@ episode: 9
 podcast: Pointer09.mp3
 type: episode
 artwork: default.jpg
-duration: 1:3:14
+duration: 01:03:14
 ---
 
 ## Note della puntata

--- a/content/post/90/index.md
+++ b/content/post/90/index.md
@@ -8,7 +8,7 @@ episode: 90
 podcast: pointer90.mp3
 type: episode
 artwork: pp90.jpeg
-duration: 0:58:37
+duration: 00:58:37
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/91/index.md
+++ b/content/post/91/index.md
@@ -9,7 +9,7 @@ podcast: pointer91.mp3
 type: episode
 artwork: pp91.jpeg
 tags: ["Quantum Computing"]
-duration: 0:27:33
+duration: 00:27:33
 ---
 
 -   [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/92/index.md
+++ b/content/post/92/index.md
@@ -8,7 +8,7 @@ episode: 92
 podcast: pointer92.mp3
 type: episode
 artwork: pp92.jpeg
-duration: 0:45:39
+duration: 00:45:39
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/93/index.md
+++ b/content/post/93/index.md
@@ -8,7 +8,7 @@ episode: 93
 podcast: pointer93.mp3
 type: episode
 artwork: pp93.png
-duration: 0:42:45
+duration: 00:42:45
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/94/index.md
+++ b/content/post/94/index.md
@@ -8,7 +8,7 @@ episode: 94
 podcast: pointer94.mp3
 type: episode
 artwork: pp94.jpeg
-duration: 0:32:32
+duration: 00:32:32
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/95/index.md
+++ b/content/post/95/index.md
@@ -8,7 +8,7 @@ episode: 95
 podcast: pointer95.mp3
 type: episode
 artwork: pp95.jpeg
-duration: 1:21:24
+duration: 01:21:24
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/96/index.md
+++ b/content/post/96/index.md
@@ -8,7 +8,7 @@ episode: 96
 podcast: pointer96.mp3
 type: episode
 artwork: pp96.jpeg
-duration: 0:38:26
+duration: 00:38:26
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/97/index.md
+++ b/content/post/97/index.md
@@ -8,7 +8,7 @@ episode: 97
 podcast: pointer97.mp3
 type: episode
 artwork: pp97.jpeg
-duration: 1:33:24
+duration: 01:33:24
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/98/index.md
+++ b/content/post/98/index.md
@@ -8,7 +8,7 @@ episode: 98
 podcast: pointer98.mp3
 type: episode
 artwork: pp98.jpeg
-duration: 1:26:41
+duration: 01:26:41
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)

--- a/content/post/99/index.md
+++ b/content/post/99/index.md
@@ -8,7 +8,7 @@ episode: 99
 podcast: pointer99.mp3
 type: episode
 artwork: pp99.png
-duration: 1:5:21
+duration: 01:05:21
 ---
 
 - [Unitevi al nostro gruppo Telegram per discutere della puntata](https://t.me/pointerpodcastgruppo)


### PR DESCRIPTION
Zero-pad the hours in the duration front matter of all episodes (e.g. 0:25:25 -> 00:25:25) so <itunes:duration> is a valid HH:MM:SS value, as required by the podcast RSS spec and the online feed validators.